### PR TITLE
Upgrade @minify-html/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@minify-html/node": "^0.10.8"
+    "@minify-html/node": "^0.16.4"
   },
   "keywords": [
     "vite",


### PR DESCRIPTION
Old versions of @minify-html/node have issues on Apple Silicon. Upgrade would pick up this fix https://github.com/wilsonzlin/minify-html/issues/172 and probably some more